### PR TITLE
Don't use count() to check if the string is empty - what is this? JS?

### DIFF
--- a/MDB2.php
+++ b/MDB2.php
@@ -756,7 +756,7 @@ class MDB2
             $parsed['dbsyntax'] = $str;
         }
 
-        if (!count($dsn)) {
+        if ($dsn == '') {
             return $parsed;
         }
 


### PR DESCRIPTION
I've done `ack -l "count\(" ./` to check if there are any other uses of `count()` with a string as the parameter. There are not.