### PR TITLE
Remove isDST parameter from mktime as it is removed in PHP 7.x

### DIFF
--- a/MDB2/Date.php
+++ b/MDB2/Date.php
@@ -122,7 +122,7 @@ class MDB2_Date
         $day = null,
         $year = null
     ) {
-        return MDB2_Date::unix2Mdbstamp(mktime($hour, $minute, $second, $month, $day, $year, -1));
+        return MDB2_Date::unix2Mdbstamp(mktime($hour, $minute, $second, $month, $day, $year));
     }
 
     // }}}
@@ -153,7 +153,7 @@ class MDB2_Date
     {
         $arr = MDB2_Date::mdbstamp2Date($mdb_timestamp);
 
-        return mktime($arr['hour'], $arr['minute'], $arr['second'], $arr['month'], $arr['day'], $arr['year'], -1);
+        return mktime($arr['hour'], $arr['minute'], $arr['second'], $arr['month'], $arr['day'], $arr['year']);
     }
 
     // }}}


### PR DESCRIPTION
See https://www.php.net/mktime documentation for isDST.