### PR TITLE
Public cleanup

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -12,7 +12,7 @@ return (new Config())
     ->setParallelConfig(ParallelConfigFactory::detect(null, null, 2 ** 18 - 1))
     ->setRules([
         '@PhpCsFixer'      => true,
-        '@PHP82Migration'  => true,
+        '@PHP8x2Migration' => true,
         'indentation_type' => true,
 
         // Overrides for (opinionated) @PhpCsFixer and @Symfony rules:
@@ -22,6 +22,9 @@ return (new Config())
 
         // Subset of statements that should be proceeded with blank line
         'blank_line_before_statement' => ['statements' => ['case', 'continue', 'declare', 'default', 'return', 'throw', 'try', 'yield', 'yield_from']],
+
+        // Allow class list for multiple extends/implements to span multiple lines
+        'class_definition' => ['multi_line_extends_each_single_line' => true],
 
         // Enforce space around concatenation operator
         'concat_space' => ['spacing' => 'one'],

--- a/MDB2/Result/Common.php
+++ b/MDB2/Result/Common.php
@@ -158,7 +158,7 @@ class MDB2_Result_Common extends MDB2_Result
      * @param mixed      $fetchmode
      * @param mixed|null $rownum
      *
-     * @return array data array on success, a MDB2 error on failure
+     * @return ($fetchmode is MDB2_FETCHMODE_OBJECT ? stdClass : array)|MDB2_Error data array on success, a MDB2 error on failure
      */
     public function fetchRow($fetchmode = MDB2_FETCHMODE_DEFAULT, $rownum = null)
     {

--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,6 @@
       "email": "mike@silverorange.com"
     }
   ],
-  "repositories": [
-    {
-      "type": "composer",
-      "url": "https://composer.silverorange.com",
-      "only": [
-        "silverorange/*"
-      ]
-    }
-  ],
   "autoload": {
     "psr-0": {
       "MDB2": ""
@@ -39,19 +30,19 @@
     "pear/pear-core-minimal": "^1.9.0"
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^3.64.0",
-    "phpstan/phpstan": "^1.12",
-    "rector/rector": "^1.2"
+    "friendsofphp/php-cs-fixer": "3.88.2",
+    "phpstan/phpstan": "^2.2",
+    "rector/rector": "^2.4"
   },
   "scripts": {
     "phpcs": "./vendor/bin/php-cs-fixer check -v",
     "phpcs:ci": "./vendor/bin/php-cs-fixer check --config=.php-cs-fixer.php --no-interaction --show-progress=none --diff --using-cache=no -vvv",
-    "phpcs:write": "./vendor/bin/php-cs-fixer fix -v",
+    "phpcs:fix": "./vendor/bin/php-cs-fixer fix -v",
     "phpstan": "./vendor/bin/phpstan analyze",
     "phpstan:ci": "./vendor/bin/phpstan analyze -vvv --no-progress --memory-limit 2G",
     "phpstan:baseline": "./vendor/bin/phpstan analyze --generate-baseline",
     "rector": "./vendor/bin/rector --dry-run",
-    "rector:write": "./vendor/bin/rector"
+    "rector:fix": "./vendor/bin/rector"
   },
   "config": {
     "sort-packages": true

--- a/rector.php
+++ b/rector.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Catch_\RemoveUnusedVariableInCatchRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
-use Rector\Php80\Rector\FunctionLike\MixedTypeRector;
 use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
 
 return RectorConfig::configure()
@@ -31,7 +30,6 @@ return RectorConfig::configure()
         // that introduce a lot of changes to legacy code bases.
         // For new projects, you should probably not skip anything.
         ClassPropertyAssignToConstructorPromotionRector::class,
-        MixedTypeRector::class,
         NullToStrictStringFuncCallArgRector::class,
         RemoveUnusedVariableInCatchRector::class,
     ])


### PR DESCRIPTION
- removes reference to private Satis
- bumps a few versions and standardizes formatting rules, commands, etc..

One unrelated change: tweak the PHPstan annotation for the `fetchRow()` function.  It returns a `stdClass` object if the mode is set to `MDB2_FETCHMODE_OBJECT` (which it often is in downstream usages) ... so this should help IDEs type hint those values better.